### PR TITLE
ColabCPP update - enable 4096 context for Llama2 based models for Google Colab

### DIFF
--- a/colab.ipynb
+++ b/colab.ipynb
@@ -1,0 +1,61 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "private_outputs": true,
+      "provenance": [],
+      "gpuType": "T4",
+      "authorship_tag": "ABX9TyOv14c2MWENhO6RJ3uy6vD7",
+      "include_colab_link": true
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    },
+    "accelerator": "GPU"
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "view-in-github",
+        "colab_type": "text"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/henk717/koboldcpp/blob/concedo/colab.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "cellView": "form",
+        "id": "uJS9i_Dltv8Y"
+      },
+      "outputs": [],
+      "source": [
+        "#@title <b>v-- Enter your model below and then click this to start Koboldcpp</b>\n",
+        "\n",
+        "Model = \"https://huggingface.co/TheBloke/airoboros-l2-13B-gpt4-1.4.1-GGML/resolve/main/airoboros-l2-13b-gpt4-1.4.1.ggmlv3.q4_0.bin\" #@param [\"\"]{allow-input: true}\n",
+        "Layers = 43 #@param [43]{allow-input: true}\n",
+        "\n",
+        "%cd /content\n",
+        "!git clone https://github.com/LostRuins/koboldcpp\n",
+        "%cd /content/koboldcpp\n",
+        "!make LLAMA_CUBLAS=1\n",
+        "\n",
+        "!wget $Model -O model.ggml\n",
+        "!wget -c https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64\n",
+        "!chmod +x cloudflared-linux-amd64\n",
+        "!nohup ./cloudflared-linux-amd64 tunnel --url http://localhost:5001 &\n",
+        "!sleep 10\n",
+        "!cat nohup.out\n",
+        "!python koboldcpp.py model.ggml --stream --usecublas 0 --gpulayers $Layers --hordeconfig concedo\n"
+      ]
+    }
+  ]
+}

--- a/colab.ipynb
+++ b/colab.ipynb
@@ -56,6 +56,7 @@
         "\n",
         "Model = \"https://huggingface.co/KoboldAI/LLaMA2-13B-Holomax-GGML/resolve/main/LLaMA2-13B-Holomax.ggmlv3.Q4_1.bin\" #@param [\"\"]{allow-input: true}\n",
         "Layers = 43 #@param [43]{allow-input: true}\n",
+        "Context = 4096 #@param [43]{allow-input: true}\n",
         "\n",
         "%cd /content\n",
         "!git clone https://github.com/LostRuins/koboldcpp\n",
@@ -68,7 +69,7 @@
         "!nohup ./cloudflared-linux-amd64 tunnel --url http://localhost:5001 &\n",
         "!sleep 10\n",
         "!cat nohup.out\n",
-        "!python koboldcpp.py model.ggml --stream --usecublas 0 --gpulayers $Layers --hordeconfig concedo\n"
+        "!python koboldcpp.py model.ggml --stream --usecublas 0 normal mmq --ropeconfig 1.0 10000 --gpulayers $Layers --context $Context --hordeconfig concedo\n"
       ]
     }
   ]

--- a/colab.ipynb
+++ b/colab.ipynb
@@ -6,7 +6,7 @@
       "private_outputs": true,
       "provenance": [],
       "gpuType": "T4",
-      "authorship_tag": "ABX9TyOv14c2MWENhO6RJ3uy6vD7",
+      "authorship_tag": "ABX9TyMz69Rx7tXm90dHIehJbO/4",
       "include_colab_link": true
     },
     "kernelspec": {
@@ -40,7 +40,7 @@
       "source": [
         "#@title <b>v-- Enter your model below and then click this to start Koboldcpp</b>\n",
         "\n",
-        "Model = \"https://huggingface.co/TheBloke/airoboros-l2-13B-gpt4-1.4.1-GGML/resolve/main/airoboros-l2-13b-gpt4-1.4.1.ggmlv3.q4_0.bin\" #@param [\"\"]{allow-input: true}\n",
+        "Model = \"https://huggingface.co/TheBloke/MythoMax-L2-13B-GGML/resolve/main/mythomax-l2-13b.ggmlv3.q4_1.bin\" #@param [\"\"]{allow-input: true}\n",
         "Layers = 43 #@param [43]{allow-input: true}\n",
         "\n",
         "%cd /content\n",

--- a/colab.ipynb
+++ b/colab.ipynb
@@ -26,7 +26,7 @@
         "colab_type": "text"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/henk717/koboldcpp/blob/concedo/colab.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+        "<a href=\"https://colab.research.google.com/github/pyroserenus/koboldcpp/blob/concedo/colab.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
       ]
     },
     {

--- a/colab.ipynb
+++ b/colab.ipynb
@@ -6,7 +6,7 @@
       "private_outputs": true,
       "provenance": [],
       "gpuType": "T4",
-      "authorship_tag": "ABX9TyMz69Rx7tXm90dHIehJbO/4",
+      "authorship_tag": "ABX9TyOHUz0/9FOVSfPrIAimx97R",
       "include_colab_link": true
     },
     "kernelspec": {
@@ -40,7 +40,7 @@
       "source": [
         "#@title <b>v-- Enter your model below and then click this to start Koboldcpp</b>\n",
         "\n",
-        "Model = \"https://huggingface.co/TheBloke/MythoMax-L2-13B-GGML/resolve/main/mythomax-l2-13b.ggmlv3.q4_1.bin\" #@param [\"\"]{allow-input: true}\n",
+        "Model = \"https://huggingface.co/KoboldAI/LLaMA2-13B-Holomax-GGML/resolve/main/LLaMA2-13B-Holomax.ggmlv3.Q4_1.bin\" #@param [\"\"]{allow-input: true}\n",
         "Layers = 43 #@param [43]{allow-input: true}\n",
         "\n",
         "%cd /content\n",

--- a/colab.ipynb
+++ b/colab.ipynb
@@ -26,7 +26,7 @@
         "colab_type": "text"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/pyroserenus/koboldcpp/blob/patch-1/colab.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+        "<a href=\"https://colab.research.google.com/github/henk717/koboldcpp/blob/concedo/colab.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
       ]
     },
     {

--- a/colab.ipynb
+++ b/colab.ipynb
@@ -6,7 +6,7 @@
       "private_outputs": true,
       "provenance": [],
       "gpuType": "T4",
-      "authorship_tag": "ABX9TyOHUz0/9FOVSfPrIAimx97R",
+      "authorship_tag": "ABX9TyMJ7PCRivS7ATHJ6Xnn2h2S",
       "include_colab_link": true
     },
     "kernelspec": {
@@ -28,6 +28,20 @@
       "source": [
         "<a href=\"https://colab.research.google.com/github/henk717/koboldcpp/blob/concedo/colab.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
       ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "#@title v-- Tap this if you play on Mobile { display-mode: \"form\" }\n",
+        "%%html\n",
+        "<b>Press play on the music player to keep the tab alive, then start KoboldAI below (Uses only 13MB of data)</b><br/>\n",
+        "<audio src=\"https://raw.githubusercontent.com/KoboldAI/KoboldAI-Client/main/colab/silence.m4a\" controls>"
+      ],
+      "metadata": {
+        "id": "KigUEDvN83j1"
+      },
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "code",

--- a/colab.ipynb
+++ b/colab.ipynb
@@ -26,7 +26,7 @@
         "colab_type": "text"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/pyroserenus/koboldcpp/blob/concedo/colab.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+        "<a href=\"https://colab.research.google.com/github/pyroserenus/koboldcpp/blob/patch-1/colab.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
       ]
     },
     {


### PR DESCRIPTION
Adjustment to cpp colab. Adds context variable and default of 4096. Previous colab notebook loaded models at koboldcpp default of 2048. T4 has no issues running full 4096 context of llama2.

Also sets rope to 1.0 10000 to prevent automatic rope scaling anomalies. Users are expected to set context to 2048 for llama1 models.

This is my first pull request and I barely know what I'm doing